### PR TITLE
feat: add a script to scan dead links

### DIFF
--- a/docs/manage/replica_manage.md
+++ b/docs/manage/replica_manage.md
@@ -11,7 +11,7 @@ sidebar_position: 13
  - 提升节点为主
  - 销毁复制组
 
-副本以及分片相关概念可以参见 [数据分片与复制](../../reference/concept_design/replica.md)
+副本以及分片相关概念可以参见 [数据分片与复制](../reference/concept_design/replica.md)
 ## 查看副本分布
 
 ```sql

--- a/docs/reference/performance/cnosdb_vs_influxdb.md
+++ b/docs/reference/performance/cnosdb_vs_influxdb.md
@@ -27,7 +27,7 @@ CPU：64 CPUs x Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
 
 2. 安装 CnosDB
 
-   参照部署文档：[安装CnosDB](../start/install.md)
+   参照部署文档：[安装CnosDB](../../start/install.md)
 
 3. 安装 InfluxDB
 

--- a/docs/reference/performance/cnosdb_vs_mysql.md
+++ b/docs/reference/performance/cnosdb_vs_mysql.md
@@ -30,7 +30,7 @@ sidebar_position: 2
 
 2. 安装 CnosDB
 
-   参照部署文档：[安装CnosDB](../start/install.md)
+   参照部署文档：[安装CnosDB](../../start/install.md)
 
 3. 安装 MySQL
 

--- a/docs/reference/performance/cnosdb_vs_timescaledb.md
+++ b/docs/reference/performance/cnosdb_vs_timescaledb.md
@@ -29,7 +29,7 @@ CPU：64 CPUs x Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
 
 2. 安装 CnosDB
 
-   参照部署文档：[安装CnosDB](../start/install.md)
+   参照部署文档：[安装CnosDB](../../start/install.md)
 
 3. 安装 TimeScaleDB
 

--- a/docs/start/quick_start.md
+++ b/docs/start/quick_start.md
@@ -592,7 +592,7 @@ SHOW QUERIES;
     | 36       | select * FROM air join sea ON air.temperature = sea.temperature; | 108709109615072923019194003831375742761 | root      | 13215126763611749424716665303609634152 | cnosdb      | SCHEDULING | 12.693345666 |
     +----------+------------------------------------------------------------------+-----------------------------------------+-----------+----------------------------------------+-------------+------------+--------------+
 
-关于 SHOW QUERIES 语句的详细信息，可以在[系统表 QUERIES](../reference/sql#queries-information-schema) 查看
+关于 SHOW QUERIES 语句的详细信息，可以在[系统表 QUERIES](../reference/sql/system_views#queries) 查看
 
 
 ## **EXPLAIN**

--- a/script/find_dead_links.py
+++ b/script/find_dead_links.py
@@ -1,0 +1,77 @@
+import os
+import re
+
+exclude_dirs = [
+    'node_modules',
+    'build',
+]
+
+def find_md_files(directory):
+    md_files = []
+    for root, dirs, files in os.walk(directory):
+        dirs[:] = [d for d in dirs if d not in exclude_dirs]
+        for file in files:
+            if file.endswith(".md"):
+                md_files.append(os.path.join(root, file))
+    return md_files
+
+def extract_links(md_file):
+    link_pattern = re.compile(r'\[(.*?)\]\((.*?)\)')
+    with open(md_file, 'r', encoding='utf-8') as file:
+        content = file.read()
+    return link_pattern.findall(content)
+
+def is_relative_link(link):
+    return link.startswith('/') or link.startswith('./') or link.startswith('../')
+
+def check_link_exists(base_dir, link_url : str):
+    if link_url.startswith('/'):
+        if link_url.find('.') >= 0 and not link_url.endswith('.md'):
+            # `link_url`s such as '/img/simple8b.png' require resources in '$repository/static/'
+            abs_path = os.path.normpath(f'./static{link_url}')
+        else:
+            # `link_url`s such as '/img/simple8b.md' require resources in '$repository/'
+            if link_url.startswith('/eco-integration/'):
+                abs_path = os.path.normpath(f'./eco-integration/1/{link_url[17:]}')
+            else:
+                abs_path = os.path.normpath(f'./{link_url[1:]}')
+    else:
+        abs_path = os.path.normpath(os.path.join(base_dir, link_url))
+
+    exists = os.path.exists(abs_path)
+    if not exists:
+        abs_path = abs_path + '.md'
+        exists = os.path.exists(abs_path)
+    return exists, abs_path
+
+def extract_header(md_file, header):
+    # For char '-' in title, replace it with '.' to match any character.
+    header_re = re.escape(header).replace('\\-', '.');
+    header_pattern = re.compile(r'^#+ [`\'"]?' + header_re + r'[`\'"]?$', re.MULTILINE | re.IGNORECASE)
+    if not os.path.isfile(md_file):
+        return False
+    with open(md_file, 'r', encoding='utf-8') as file:
+        content = file.read()
+    return header_pattern.search(content) is not None
+
+def main(directory):
+    md_files = find_md_files(directory)
+    for md_file in md_files:
+        md_file_dir = os.path.dirname(md_file)
+        link_name_urls = extract_links(md_file)
+        for (link_name, link) in link_name_urls:
+            if is_relative_link(link):
+                # Split the link '../a/b/c#header' into path and header
+                path, header = (link.split('#') + [None])[:2]
+                exists, abs_path = check_link_exists(md_file_dir, path)
+                # print(md_file, exists, path, header, abs_path)
+                if not exists:
+                    print(f'Broken link: [{link_name}]({link}) in file: {md_file}')
+                elif header and not extract_header(abs_path, header):
+                    print(f'Missing header: #{header} in file: {abs_path} (linked by [{link_name}]({link}) from file: {md_file})')
+
+if __name__ == "__main__":
+    # main("./docs")
+
+    directory = input("Enter a directory to scan: ")
+    main(directory)


### PR DESCRIPTION
## Usages

```shell
❯ python ./script/find_dead_links.py 
Enter a directory to scan: ./docs
Missing header: #queries-information-schema in file: docs/reference/sql (linked from file: ./docs/start/quick_start.md)
Broken link: [数据分片与复制](../../reference/concept_design/replica.md) in file: ./docs/manage/replica_manage.md
```

- `Missing header`, the link to a markdown header couldn't be found in the linked file.
- `Broken link`, the link to a markdown file couldn't be found.

## After fixed

```shell
❯ python ./script/find_dead_links.py 
Enter a directory to scan: ./docs
Missing header: #cluster in file: docs/reference/config.md (linked by [`cluster`](../reference/config#cluster) from file: ./docs/manage/cluster_manage.md)
Missing header: #node-basic in file: docs/reference/config.md (linked by [配置文件](../reference/config.md#node-basic) from file: ./docs/manage/monitor.md)
Missing header: #数据管理 in file: docs/reference/concept_design/arch.md (linked by [分片规则](../concept_design/arch#数据管理) from file: ./docs/reference/sql/ddl.md)
```

